### PR TITLE
merge regression: remove duplicate a64fx entries

### DIFF
--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -205,7 +205,6 @@ static const char *valid_cpus[] = {
     ARM_CPU_TYPE_NAME("cortex-a53"),
     ARM_CPU_TYPE_NAME("cortex-a57"),
     ARM_CPU_TYPE_NAME("cortex-a72"),
-    ARM_CPU_TYPE_NAME("a64fx"),
     ARM_CPU_TYPE_NAME("morello"),
     ARM_CPU_TYPE_NAME("a64fx"),
     ARM_CPU_TYPE_NAME("host"),

--- a/target/arm/cpu64.c
+++ b/target/arm/cpu64.c
@@ -1032,7 +1032,6 @@ static const ARMCPUInfo aarch64_cpus[] = {
     { .name = "cortex-a57",         .initfn = aarch64_a57_initfn },
     { .name = "cortex-a53",         .initfn = aarch64_a53_initfn },
     { .name = "cortex-a72",         .initfn = aarch64_a72_initfn },
-    { .name = "a64fx",              .initfn = aarch64_a64fx_initfn },
     { .name = "morello",            .initfn = aarch64_morello_initfn },
     { .name = "a64fx",              .initfn = aarch64_a64fx_initfn },
     { .name = "max",                .initfn = aarch64_max_initfn },


### PR DESCRIPTION
Remove duplicate a64fx entries that make qemu-system-morello fail.

[martin.kaiser@nb282 qemu]$ ./build/qemu-system-morello Registering `a64fx-arm-cpu' which already exists
Aborted (core dumped)