### PR TITLE
two small fixes for codasip-rebased-20250910

### DIFF
--- a/target/riscv/cheri-archspecific-early.h
+++ b/target/riscv/cheri-archspecific-early.h
@@ -152,6 +152,9 @@ enum CheriSCR {
 #ifdef TARGET_CHERI_RISCV_V9
 #define CHERI_TAG_CLEAR_ON_INVALID(env) (env_archcpu(env)->cfg.ext_cheri_v9)
 #define CHERI_NO_RELOCATION(env)        (env_archcpu(env)->cfg.ext_cheri_v9)
+#elif defined(TARGET_CHERI_RISCV_STD_093)
+#define CHERI_TAG_CLEAR_ON_INVALID(env) true
+#define CHERI_NO_RELOCATION(env)        false
 #else
 #define CHERI_TAG_CLEAR_ON_INVALID(env) false
 #define CHERI_NO_RELOCATION(env)        false

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -832,6 +832,7 @@ static void riscv_cpu_reset(DeviceState *dev)
     null_capability(&env->vstdc);
 #endif
 
+   env->last_cap_type = CapEx093_Type_None;
 #endif /* TARGET_CHERI */
 #ifdef CONFIG_DEBUG_TCG
     env->_pc_is_current = true;


### PR DESCRIPTION
two small fixes to make the codasip-rebased-20250910 branch work with our cheri linux and our internal tests